### PR TITLE
Feature/OTLP GRPC exporter autoconf

### DIFF
--- a/libs/spring-boot-micrometer-tracing-autoconf/build.gradle.kts
+++ b/libs/spring-boot-micrometer-tracing-autoconf/build.gradle.kts
@@ -19,12 +19,14 @@ base.archivesName.set(vArtifactId)
 
 val springBootVersion = "3.0.2"
 val micrometerTracingVersion = "1.1.1"
+val otelVersion = "1.26.0"
 val junitJupiterVersion = "5.9.2"
 
 dependencies {
     compileOnly("io.micrometer:micrometer-tracing:${micrometerTracingVersion}")
     compileOnly("org.springframework.boot:spring-boot-starter-actuator:${springBootVersion}")
     compileOnly("org.springframework.boot:spring-boot-actuator-autoconfigure:${springBootVersion}")
+    compileOnly("io.opentelemetry:opentelemetry-exporter-otlp:${otelVersion}")
 
     testImplementation("org.junit.jupiter:junit-jupiter-api:$junitJupiterVersion")
     testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine:$junitJupiterVersion")

--- a/libs/spring-boot-micrometer-tracing-autoconf/src/main/java/com/digma/springboot/otlp/autoconf/DigmaOtlpAutoConfiguration.java
+++ b/libs/spring-boot-micrometer-tracing-autoconf/src/main/java/com/digma/springboot/otlp/autoconf/DigmaOtlpAutoConfiguration.java
@@ -10,6 +10,10 @@ import org.springframework.context.annotation.Bean;
 
 /**
  * OpenTelemetry ( otel ) AutoConfiguration for OtlpGrpcSpanExporter
+ *
+ * seen this class works for spring boot versions:
+ *  3.0.2
+ *  3.1.1
  */
 @AutoConfiguration
 @ConditionalOnClass(OtlpGrpcSpanExporter.class)

--- a/libs/spring-boot-micrometer-tracing-autoconf/src/main/java/com/digma/springboot/otlp/autoconf/DigmaOtlpAutoConfiguration.java
+++ b/libs/spring-boot-micrometer-tracing-autoconf/src/main/java/com/digma/springboot/otlp/autoconf/DigmaOtlpAutoConfiguration.java
@@ -22,7 +22,7 @@ public class DigmaOtlpAutoConfiguration {
     @Bean
     @ConditionalOnProperty(prefix = "management.otlp.tracing", name = "endpoint")
     @ConditionalOnEnabledTracing
-    OtlpGrpcSpanExporter otlpGrpcSpanExporter(@Value("management.otlp.tracing.endpoint") String otlpEndpoint) {
+    OtlpGrpcSpanExporter otlpGrpcSpanExporter(@Value("${management.otlp.tracing.endpoint}") String otlpEndpoint) {
         OtlpGrpcSpanExporter bean = OtlpGrpcSpanExporter.builder()
                 .setEndpoint(otlpEndpoint)
                 .build();

--- a/libs/spring-boot-micrometer-tracing-autoconf/src/main/java/com/digma/springboot/otlp/autoconf/DigmaOtlpAutoConfiguration.java
+++ b/libs/spring-boot-micrometer-tracing-autoconf/src/main/java/com/digma/springboot/otlp/autoconf/DigmaOtlpAutoConfiguration.java
@@ -1,0 +1,32 @@
+package com.digma.springboot.otlp.autoconf;
+
+import io.opentelemetry.exporter.otlp.trace.OtlpGrpcSpanExporter;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.actuate.autoconfigure.tracing.ConditionalOnEnabledTracing;
+import org.springframework.boot.autoconfigure.AutoConfiguration;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.context.annotation.Bean;
+
+/**
+ * OpenTelemetry ( otel ) AutoConfiguration for OtlpGrpcSpanExporter
+ */
+@AutoConfiguration
+@ConditionalOnClass(OtlpGrpcSpanExporter.class)
+public class DigmaOtlpAutoConfiguration {
+
+    /**
+     * see class org.springframework.boot.actuate.autoconfigure.tracing.otlp.OtlpAutoConfiguration (since 3.1)
+     * see class org.springframework.boot.actuate.autoconfigure.tracing.otlp.OtlpProperties (since 3.1)
+     */
+    @Bean
+    @ConditionalOnProperty(prefix = "management.otlp.tracing", name = "endpoint")
+    @ConditionalOnEnabledTracing
+    OtlpGrpcSpanExporter otlpGrpcSpanExporter(@Value("management.otlp.tracing.endpoint") String otlpEndpoint) {
+        OtlpGrpcSpanExporter bean = OtlpGrpcSpanExporter.builder()
+                .setEndpoint(otlpEndpoint)
+                .build();
+        return bean;
+    }
+
+}

--- a/libs/spring-boot-micrometer-tracing-autoconf/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
+++ b/libs/spring-boot-micrometer-tracing-autoconf/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
@@ -1,1 +1,2 @@
 com.digma.springboot.micrometer.autoconf.ObservedAutoConfiguration
+com.digma.springboot.otlp.autoconf.DigmaOtlpAutoConfiguration

--- a/version.gradle.kts
+++ b/version.gradle.kts
@@ -1,5 +1,5 @@
 // keep the name theVersion and the val definition since script update_version.sh maintains it
-val theVersion = "0.7.3-SNAPSHOT"
+val theVersion = "0.7.4"
 
 allprojects {
     group = "io.github.digma-ai"

--- a/version.gradle.kts
+++ b/version.gradle.kts
@@ -1,5 +1,5 @@
 // keep the name theVersion and the val definition since script update_version.sh maintains it
-val theVersion = "0.7.2"
+val theVersion = "0.7.3-SNAPSHOT"
 
 allprojects {
     group = "io.github.digma-ai"


### PR DESCRIPTION
loading class `OtlpGrpcSpanExporter` based on config entry `management.otlp.tracing.endpoint`
loading it instead of spring-boot default one `OtlpHttpSpanExporter`  see class [OtlpAutoConfiguration](https://github.com/spring-projects/spring-boot/blob/main/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/tracing/otlp/OtlpAutoConfiguration.java#L62)
