### PR TITLE
Feature/SpringBoot Micrometer Tracing - allow OTEL resources attributes via environment variable

### DIFF
--- a/instrumentation/spring/spring-boot-autoconfigure/build.gradle.kts
+++ b/instrumentation/spring/spring-boot-autoconfigure/build.gradle.kts
@@ -20,7 +20,7 @@ project.description = "Digma, Auto-configures OpenTelemetry instrumentation for 
 val OPENTELEMETRY_VERSION = "1.21.0"
 val OPENTELEMETRY_ALPHA_VERSION = "1.21.0-alpha"
 val springBootVersion = "2.7.5"
-val junitJupiterVersion = "5.9.1"
+val junitJupiterVersion = "5.10.1"
 
 dependencies {
     implementation(project(":instrumentation:common"))

--- a/libs/spring-boot-micrometer-tracing-autoconf/build.gradle.kts
+++ b/libs/spring-boot-micrometer-tracing-autoconf/build.gradle.kts
@@ -17,10 +17,19 @@ java {
 
 base.archivesName.set(vArtifactId)
 
-val springBootVersion = "3.0.2"
-val micrometerTracingVersion = "1.1.1"
-val otelVersion = "1.26.0"
-val junitJupiterVersion = "5.9.2"
+// spring boot + opentelemetry metrics
+//  |-------------+--------------+
+//  | spring boot | OTEL version |
+//  |-------------+--------------+
+//  |  3.0.x      |  1.19.0      |
+//  |  3.1.x      |  1.25.0      |
+//  |  3.2.x      |  1.31.0      |
+//  |-------------+--------------+
+
+val springBootVersion = "3.1.6"
+val micrometerTracingVersion = "1.1.7"
+val otelVersion = "1.25.0"
+val junitJupiterVersion = "5.9.3"
 
 dependencies {
     compileOnly("io.micrometer:micrometer-tracing:${micrometerTracingVersion}")

--- a/libs/spring-boot-micrometer-tracing-autoconf/build.gradle.kts
+++ b/libs/spring-boot-micrometer-tracing-autoconf/build.gradle.kts
@@ -35,6 +35,7 @@ dependencies {
     compileOnly("io.micrometer:micrometer-tracing:${micrometerTracingVersion}")
     compileOnly("org.springframework.boot:spring-boot-starter-actuator:${springBootVersion}")
     compileOnly("org.springframework.boot:spring-boot-actuator-autoconfigure:${springBootVersion}")
+    compileOnly("io.opentelemetry:opentelemetry-sdk:${otelVersion}")
     compileOnly("io.opentelemetry:opentelemetry-exporter-otlp:${otelVersion}")
 
     testImplementation("org.junit.jupiter:junit-jupiter-api:$junitJupiterVersion")

--- a/libs/spring-boot-micrometer-tracing-autoconf/src/main/java/com/digma/springboot/otlp/autoconf/DigmaOpenTelemetryProperties.java
+++ b/libs/spring-boot-micrometer-tracing-autoconf/src/main/java/com/digma/springboot/otlp/autoconf/DigmaOpenTelemetryProperties.java
@@ -1,0 +1,33 @@
+package com.digma.springboot.otlp.autoconf;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * exact file content as in org.springframework.boot.actuate.autoconfigure.opentelemetry.OpenTelemetryProperties (since sb 3.2.0)
+ *
+ * see org.springframework.boot.actuate.autoconfigure.opentelemetry.OpenTelemetryProperties
+ *
+ * care about property (and system property) entries:
+ * management.opentelemetry.resource-attributes.key1=value1
+ *  (environment variable equivalent : MANAGEMENT_OPENTELEMETRY_RESOURCE-ATTRIBUTES_key2=value2
+ */
+@ConfigurationProperties(prefix = "management.opentelemetry")
+public class DigmaOpenTelemetryProperties {
+
+    /**
+     * Resource attributes.
+     */
+    private Map<String, String> resourceAttributes = new HashMap<>();
+
+    public Map<String, String> getResourceAttributes() {
+        return this.resourceAttributes;
+    }
+
+    public void setResourceAttributes(Map<String, String> resourceAttributes) {
+        this.resourceAttributes = resourceAttributes;
+    }
+
+}

--- a/libs/spring-boot-micrometer-tracing-autoconf/src/main/java/com/digma/springboot/otlp/autoconf/DigmaOpenTelemetryProperties.java
+++ b/libs/spring-boot-micrometer-tracing-autoconf/src/main/java/com/digma/springboot/otlp/autoconf/DigmaOpenTelemetryProperties.java
@@ -9,6 +9,8 @@ import java.util.Map;
  * exact file content as in org.springframework.boot.actuate.autoconfigure.opentelemetry.OpenTelemetryProperties (since sb 3.2.0)
  *
  * see org.springframework.boot.actuate.autoconfigure.opentelemetry.OpenTelemetryProperties
+ * see https://github.com/spring-projects/spring-boot/blob/main/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/opentelemetry/OpenTelemetryProperties.java
+ * see https://github.com/spring-projects/spring-boot/blob/3.2.x/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/opentelemetry/OpenTelemetryProperties.java
  *
  * care about property (and system property) entries:
  * management.opentelemetry.resource-attributes.key1=value1

--- a/libs/spring-boot-micrometer-tracing-autoconf/src/main/java/com/digma/springboot/otlp/autoconf/DigmaOtelSpringBootCommon.java
+++ b/libs/spring-boot-micrometer-tracing-autoconf/src/main/java/com/digma/springboot/otlp/autoconf/DigmaOtelSpringBootCommon.java
@@ -1,0 +1,31 @@
+package com.digma.springboot.otlp.autoconf;
+
+import io.opentelemetry.api.common.AttributeKey;
+import io.opentelemetry.api.common.Attributes;
+import io.opentelemetry.sdk.resources.Resource;
+import io.opentelemetry.sdk.resources.ResourceBuilder;
+import org.springframework.core.env.Environment;
+
+public final class DigmaOtelSpringBootCommon {
+
+    /**
+     * Default value for application name if {@code spring.application.name} is not set.
+     */
+    protected static final String DEFAULT_APPLICATION_NAME = "application";
+
+    protected static final AttributeKey<String> ATTRIBUTE_KEY_SERVICE_NAME = AttributeKey.stringKey("service.name");
+
+    // same code as in DigmaOtelSpringBootVersion3dot1AutoConfiguration
+    protected static Resource openTelemetryResourceAsInSpring3dot2(Environment environment, DigmaOpenTelemetryProperties properties) {
+        String applicationName = environment.getProperty("spring.application.name", DEFAULT_APPLICATION_NAME);
+        return Resource.getDefault()
+                .merge(Resource.create(Attributes.of(ATTRIBUTE_KEY_SERVICE_NAME, applicationName)))
+                .merge(toResource(properties));
+    }
+
+    protected static Resource toResource(DigmaOpenTelemetryProperties properties) {
+        ResourceBuilder builder = Resource.builder();
+        properties.getResourceAttributes().forEach(builder::put);
+        return builder.build();
+    }
+}

--- a/libs/spring-boot-micrometer-tracing-autoconf/src/main/java/com/digma/springboot/otlp/autoconf/DigmaOtelSpringBootVersion3dot0AutoConfiguration.java
+++ b/libs/spring-boot-micrometer-tracing-autoconf/src/main/java/com/digma/springboot/otlp/autoconf/DigmaOtelSpringBootVersion3dot0AutoConfiguration.java
@@ -1,0 +1,56 @@
+package com.digma.springboot.otlp.autoconf;
+
+import io.opentelemetry.sdk.OpenTelemetrySdk;
+import io.opentelemetry.sdk.resources.Resource;
+import io.opentelemetry.sdk.trace.SdkTracerProvider;
+import io.opentelemetry.sdk.trace.SdkTracerProviderBuilder;
+import io.opentelemetry.sdk.trace.SpanProcessor;
+import io.opentelemetry.sdk.trace.samplers.Sampler;
+import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.boot.autoconfigure.AutoConfiguration;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingClass;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.core.env.Environment;
+
+import java.util.Objects;
+import java.util.stream.Stream;
+
+import static com.digma.springboot.otlp.autoconf.DigmaOtelSpringBootVersion3dot1AutoConfiguration.openTelemetryResourceAsInSpring3dot2;
+
+/**
+ * support spring boot 3.0
+ */
+@AutoConfiguration
+@ConditionalOnClass(OpenTelemetrySdk.class)
+@EnableConfigurationProperties(DigmaOpenTelemetryProperties.class)
+public class DigmaOtelSpringBootVersion3dot0AutoConfiguration {
+
+    /**
+     * SdkTracerProviderBuilderCustomizer exists since 3.1.0 thats why conditioning on missing of it
+     *
+     *  @see org.springframework.boot.actuate.autoconfigure.tracing.SdkTracerProviderBuilderCustomizer (since 3.1.0)
+     *  https://github.com/spring-projects/spring-boot/blob/3.1.x/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/tracing/SdkTracerProviderBuilderCustomizer.java
+     */
+    // support spring boot 3.0
+    @Configuration(proxyBeanMethods = false)
+    @ConditionalOnMissingClass("org.springframework.boot.actuate.autoconfigure.tracing.SdkTracerProviderBuilderCustomizer")
+    static class SpringBoot3dot0Configuration {
+
+        /**
+         * took same code as in 3.1.x - just init the resource with #openTelemetryResourceAsInSpring3dot2.
+         * see https://github.com/spring-projects/spring-boot/blob/3.1.x/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/tracing/OpenTelemetryAutoConfiguration.java#L102
+         */
+        @Bean
+        SdkTracerProvider sb3dot0OtelSdkTracerProvider(Environment environment, ObjectProvider<SpanProcessor> spanProcessors, Sampler sampler, DigmaOpenTelemetryProperties properties) {
+            Resource springResource = openTelemetryResourceAsInSpring3dot2(environment, properties);
+            SdkTracerProviderBuilder builder = SdkTracerProvider.builder().setSampler(sampler).setResource(Resource.getDefault().merge(springResource));
+            Stream<SpanProcessor> var10000 = spanProcessors.orderedStream();
+            Objects.requireNonNull(builder);
+            var10000.forEach(builder::addSpanProcessor);
+            return builder.build();
+        }
+    }
+}

--- a/libs/spring-boot-micrometer-tracing-autoconf/src/main/java/com/digma/springboot/otlp/autoconf/DigmaOtelSpringBootVersion3dot0AutoConfiguration.java
+++ b/libs/spring-boot-micrometer-tracing-autoconf/src/main/java/com/digma/springboot/otlp/autoconf/DigmaOtelSpringBootVersion3dot0AutoConfiguration.java
@@ -13,6 +13,7 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingClas
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Primary;
 import org.springframework.core.env.Environment;
 
 import java.util.Objects;
@@ -44,6 +45,7 @@ public class DigmaOtelSpringBootVersion3dot0AutoConfiguration {
          * see https://github.com/spring-projects/spring-boot/blob/3.1.x/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/tracing/OpenTelemetryAutoConfiguration.java#L102
          */
         @Bean
+        @Primary // making it primary since 3.0 also provides such, so make sure that wiring will work with this one
         SdkTracerProvider sb3dot0OtelSdkTracerProvider(Environment environment, ObjectProvider<SpanProcessor> spanProcessors, Sampler sampler, DigmaOpenTelemetryProperties properties) {
             Resource springResource = openTelemetryResourceAsInSpring3dot2(environment, properties);
             SdkTracerProviderBuilder builder = SdkTracerProvider.builder().setSampler(sampler).setResource(Resource.getDefault().merge(springResource));

--- a/libs/spring-boot-micrometer-tracing-autoconf/src/main/java/com/digma/springboot/otlp/autoconf/DigmaOtelSpringBootVersion3dot0AutoConfiguration.java
+++ b/libs/spring-boot-micrometer-tracing-autoconf/src/main/java/com/digma/springboot/otlp/autoconf/DigmaOtelSpringBootVersion3dot0AutoConfiguration.java
@@ -23,6 +23,11 @@ import static com.digma.springboot.otlp.autoconf.DigmaOtelSpringBootCommon.openT
 
 /**
  * support spring boot 3.0
+ *
+ * checked with versions:
+ *  3.0
+ *  3.1
+ *  3.2
  */
 @AutoConfiguration
 @ConditionalOnClass(OpenTelemetrySdk.class)
@@ -45,7 +50,8 @@ public class DigmaOtelSpringBootVersion3dot0AutoConfiguration {
          * see https://github.com/spring-projects/spring-boot/blob/3.1.x/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/tracing/OpenTelemetryAutoConfiguration.java#L102
          */
         @Bean
-        @Primary // making it primary since 3.0 also provides such, so make sure that wiring will work with this one
+        @Primary
+        // making it primary since 3.0 also provides such, so make sure that wiring will work with this one
         SdkTracerProvider sb3dot0OtelSdkTracerProvider(Environment environment, ObjectProvider<SpanProcessor> spanProcessors, Sampler sampler, DigmaOpenTelemetryProperties properties) {
             Resource springResource = openTelemetryResourceAsInSpring3dot2(environment, properties);
             SdkTracerProviderBuilder builder = SdkTracerProvider.builder().setSampler(sampler).setResource(Resource.getDefault().merge(springResource));

--- a/libs/spring-boot-micrometer-tracing-autoconf/src/main/java/com/digma/springboot/otlp/autoconf/DigmaOtelSpringBootVersion3dot0AutoConfiguration.java
+++ b/libs/spring-boot-micrometer-tracing-autoconf/src/main/java/com/digma/springboot/otlp/autoconf/DigmaOtelSpringBootVersion3dot0AutoConfiguration.java
@@ -18,7 +18,7 @@ import org.springframework.core.env.Environment;
 import java.util.Objects;
 import java.util.stream.Stream;
 
-import static com.digma.springboot.otlp.autoconf.DigmaOtelSpringBootVersion3dot1AutoConfiguration.openTelemetryResourceAsInSpring3dot2;
+import static com.digma.springboot.otlp.autoconf.DigmaOtelSpringBootCommon.openTelemetryResourceAsInSpring3dot2;
 
 /**
  * support spring boot 3.0

--- a/libs/spring-boot-micrometer-tracing-autoconf/src/main/java/com/digma/springboot/otlp/autoconf/DigmaOtelSpringBootVersion3dot1AutoConfiguration.java
+++ b/libs/spring-boot-micrometer-tracing-autoconf/src/main/java/com/digma/springboot/otlp/autoconf/DigmaOtelSpringBootVersion3dot1AutoConfiguration.java
@@ -5,7 +5,7 @@ import io.opentelemetry.sdk.trace.SdkTracerProviderBuilder;
 import org.springframework.boot.actuate.autoconfigure.tracing.SdkTracerProviderBuilderCustomizer;
 import org.springframework.boot.autoconfigure.AutoConfiguration;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
-import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingClass;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.core.env.Environment;
@@ -13,15 +13,21 @@ import org.springframework.core.env.Environment;
 import static com.digma.springboot.otlp.autoconf.DigmaOtelSpringBootCommon.openTelemetryResourceAsInSpring3dot2;
 
 /**
+ * support spring boot 3.1.0
  * inspired by class org.springframework.boot.actuate.autoconfigure.opentelemetry.OpenTelemetryAutoConfiguration since version 3.2.0
  *
  * https://github.com/spring-projects/spring-boot/blob/main/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/opentelemetry/OpenTelemetryAutoConfiguration.java
  * https://github.com/spring-projects/spring-boot/blob/3.2.x/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/opentelemetry/OpenTelemetryAutoConfiguration.java
+ *
+ * checked with versions:
+ *  3.0
+ *  3.1
+ *  3.2
  */
 @AutoConfiguration
 @ConditionalOnClass(name = {
-        "org.springframework.boot.actuate.autoconfigure.tracing.SdkTracerProviderBuilderCustomizer",
-        "io.opentelemetry.sdk.OpenTelemetrySdk"
+        "org.springframework.boot.actuate.autoconfigure.tracing.SdkTracerProviderBuilderCustomizer", // this class exists since 3.1
+        "io.opentelemetry.sdk.OpenTelemetrySdk" // relates to OTEL at all
 })
 @EnableConfigurationProperties(DigmaOpenTelemetryProperties.class)
 public class DigmaOtelSpringBootVersion3dot1AutoConfiguration {
@@ -31,7 +37,7 @@ public class DigmaOtelSpringBootVersion3dot1AutoConfiguration {
      * in version 3.2.0 the class Resource is being provided - thats why conditioning on it
      */
     @Bean
-    @ConditionalOnMissingBean(Resource.class)
+    @ConditionalOnMissingClass("org.springframework.boot.actuate.autoconfigure.opentelemetry.OpenTelemetryProperties") // this class exists since 3.2, so skip this bean if its 3.2 or later
     SdkTracerProviderBuilderCustomizer otelSdkTracerProviderBuilderCustomizer(Environment environment, DigmaOpenTelemetryProperties properties) {
         return new ResourceAttributesSdkCustomizer(environment, properties);
     }

--- a/libs/spring-boot-micrometer-tracing-autoconf/src/main/java/com/digma/springboot/otlp/autoconf/DigmaOtelSpringBootVersion3dot1AutoConfiguration.java
+++ b/libs/spring-boot-micrometer-tracing-autoconf/src/main/java/com/digma/springboot/otlp/autoconf/DigmaOtelSpringBootVersion3dot1AutoConfiguration.java
@@ -16,6 +16,9 @@ import org.springframework.core.env.Environment;
 
 /**
  * inspired by class org.springframework.boot.actuate.autoconfigure.opentelemetry.OpenTelemetryAutoConfiguration since version 3.2.0
+ *
+ * https://github.com/spring-projects/spring-boot/blob/main/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/opentelemetry/OpenTelemetryAutoConfiguration.java
+ * https://github.com/spring-projects/spring-boot/blob/3.2.x/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/opentelemetry/OpenTelemetryAutoConfiguration.java
  */
 @AutoConfiguration
 @ConditionalOnClass(OpenTelemetrySdk.class)

--- a/libs/spring-boot-micrometer-tracing-autoconf/src/main/java/com/digma/springboot/otlp/autoconf/DigmaOtelSpringBootVersion3dot1AutoConfiguration.java
+++ b/libs/spring-boot-micrometer-tracing-autoconf/src/main/java/com/digma/springboot/otlp/autoconf/DigmaOtelSpringBootVersion3dot1AutoConfiguration.java
@@ -1,10 +1,6 @@
 package com.digma.springboot.otlp.autoconf;
 
-import io.opentelemetry.api.common.AttributeKey;
-import io.opentelemetry.api.common.Attributes;
-import io.opentelemetry.sdk.OpenTelemetrySdk;
 import io.opentelemetry.sdk.resources.Resource;
-import io.opentelemetry.sdk.resources.ResourceBuilder;
 import io.opentelemetry.sdk.trace.SdkTracerProviderBuilder;
 import org.springframework.boot.actuate.autoconfigure.tracing.SdkTracerProviderBuilderCustomizer;
 import org.springframework.boot.autoconfigure.AutoConfiguration;
@@ -14,6 +10,8 @@ import org.springframework.boot.context.properties.EnableConfigurationProperties
 import org.springframework.context.annotation.Bean;
 import org.springframework.core.env.Environment;
 
+import static com.digma.springboot.otlp.autoconf.DigmaOtelSpringBootCommon.openTelemetryResourceAsInSpring3dot2;
+
 /**
  * inspired by class org.springframework.boot.actuate.autoconfigure.opentelemetry.OpenTelemetryAutoConfiguration since version 3.2.0
  *
@@ -21,17 +19,12 @@ import org.springframework.core.env.Environment;
  * https://github.com/spring-projects/spring-boot/blob/3.2.x/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/opentelemetry/OpenTelemetryAutoConfiguration.java
  */
 @AutoConfiguration
-@ConditionalOnClass(OpenTelemetrySdk.class)
+@ConditionalOnClass(name = {
+        "org.springframework.boot.actuate.autoconfigure.tracing.SdkTracerProviderBuilderCustomizer",
+        "io.opentelemetry.sdk.OpenTelemetrySdk"
+})
 @EnableConfigurationProperties(DigmaOpenTelemetryProperties.class)
 public class DigmaOtelSpringBootVersion3dot1AutoConfiguration {
-
-    /**
-     * Default value for application name if {@code spring.application.name} is not set.
-     */
-    protected static final String DEFAULT_APPLICATION_NAME = "application";
-
-    protected static final AttributeKey<String> ATTRIBUTE_KEY_SERVICE_NAME = AttributeKey.stringKey("service.name");
-
 
     /**
      *
@@ -60,17 +53,4 @@ public class DigmaOtelSpringBootVersion3dot1AutoConfiguration {
         }
     }
 
-    // same code as in DigmaOtelSpringBootVersion3dot1AutoConfiguration
-    protected static Resource openTelemetryResourceAsInSpring3dot2(Environment environment, DigmaOpenTelemetryProperties properties) {
-        String applicationName = environment.getProperty("spring.application.name", DEFAULT_APPLICATION_NAME);
-        return Resource.getDefault()
-                .merge(Resource.create(Attributes.of(ATTRIBUTE_KEY_SERVICE_NAME, applicationName)))
-                .merge(toResource(properties));
-    }
-
-    protected static Resource toResource(DigmaOpenTelemetryProperties properties) {
-        ResourceBuilder builder = Resource.builder();
-        properties.getResourceAttributes().forEach(builder::put);
-        return builder.build();
-    }
 }

--- a/libs/spring-boot-micrometer-tracing-autoconf/src/main/java/com/digma/springboot/otlp/autoconf/DigmaOtelSpringBootVersion3dot1AutoConfiguration.java
+++ b/libs/spring-boot-micrometer-tracing-autoconf/src/main/java/com/digma/springboot/otlp/autoconf/DigmaOtelSpringBootVersion3dot1AutoConfiguration.java
@@ -1,0 +1,73 @@
+package com.digma.springboot.otlp.autoconf;
+
+import io.opentelemetry.api.common.AttributeKey;
+import io.opentelemetry.api.common.Attributes;
+import io.opentelemetry.sdk.OpenTelemetrySdk;
+import io.opentelemetry.sdk.resources.Resource;
+import io.opentelemetry.sdk.resources.ResourceBuilder;
+import io.opentelemetry.sdk.trace.SdkTracerProviderBuilder;
+import org.springframework.boot.actuate.autoconfigure.tracing.SdkTracerProviderBuilderCustomizer;
+import org.springframework.boot.autoconfigure.AutoConfiguration;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.core.env.Environment;
+
+/**
+ * inspired by class org.springframework.boot.actuate.autoconfigure.opentelemetry.OpenTelemetryAutoConfiguration since version 3.2.0
+ */
+@AutoConfiguration
+@ConditionalOnClass(OpenTelemetrySdk.class)
+@EnableConfigurationProperties(DigmaOpenTelemetryProperties.class)
+public class DigmaOtelSpringBootVersion3dot1AutoConfiguration {
+
+    /**
+     * Default value for application name if {@code spring.application.name} is not set.
+     */
+    protected static final String DEFAULT_APPLICATION_NAME = "application";
+
+    protected static final AttributeKey<String> ATTRIBUTE_KEY_SERVICE_NAME = AttributeKey.stringKey("service.name");
+
+
+    /**
+     *
+     * in version 3.2.0 the class Resource is being provided - thats why conditioning on it
+     */
+    @Bean
+    @ConditionalOnMissingBean(Resource.class)
+    SdkTracerProviderBuilderCustomizer otelSdkTracerProviderBuilderCustomizer(Environment environment, DigmaOpenTelemetryProperties properties) {
+        return new ResourceAttributesSdkCustomizer(environment, properties);
+    }
+
+    static class ResourceAttributesSdkCustomizer implements SdkTracerProviderBuilderCustomizer {
+        //	class Abc {
+        Environment environment;
+        DigmaOpenTelemetryProperties properties;
+
+        public ResourceAttributesSdkCustomizer(Environment environment, DigmaOpenTelemetryProperties properties) {
+            this.environment = environment;
+            this.properties = properties;
+        }
+
+        @Override
+        public void customize(SdkTracerProviderBuilder builder) {
+            Resource resource = openTelemetryResourceAsInSpring3dot2(environment, properties);
+            builder.setResource(resource);
+        }
+    }
+
+    // same code as in DigmaOtelSpringBootVersion3dot1AutoConfiguration
+    protected static Resource openTelemetryResourceAsInSpring3dot2(Environment environment, DigmaOpenTelemetryProperties properties) {
+        String applicationName = environment.getProperty("spring.application.name", DEFAULT_APPLICATION_NAME);
+        return Resource.getDefault()
+                .merge(Resource.create(Attributes.of(ATTRIBUTE_KEY_SERVICE_NAME, applicationName)))
+                .merge(toResource(properties));
+    }
+
+    protected static Resource toResource(DigmaOpenTelemetryProperties properties) {
+        ResourceBuilder builder = Resource.builder();
+        properties.getResourceAttributes().forEach(builder::put);
+        return builder.build();
+    }
+}

--- a/libs/spring-boot-micrometer-tracing-autoconf/src/main/java/com/digma/springboot/otlp/autoconf/DigmaOtlpAutoConfiguration.java
+++ b/libs/spring-boot-micrometer-tracing-autoconf/src/main/java/com/digma/springboot/otlp/autoconf/DigmaOtlpAutoConfiguration.java
@@ -14,6 +14,7 @@ import org.springframework.context.annotation.Bean;
  * seen this class works for spring boot versions:
  *  3.0.2
  *  3.1.1
+ *  3.2.0
  */
 @AutoConfiguration
 @ConditionalOnClass(OtlpGrpcSpanExporter.class)

--- a/libs/spring-boot-micrometer-tracing-autoconf/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
+++ b/libs/spring-boot-micrometer-tracing-autoconf/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
@@ -1,3 +1,4 @@
 com.digma.springboot.micrometer.autoconf.ObservedAutoConfiguration
 com.digma.springboot.otlp.autoconf.DigmaOtlpAutoConfiguration
+com.digma.springboot.otlp.autoconf.DigmaOtelSpringBootVersion3dot0AutoConfiguration
 com.digma.springboot.otlp.autoconf.DigmaOtelSpringBootVersion3dot1AutoConfiguration

--- a/libs/spring-boot-micrometer-tracing-autoconf/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
+++ b/libs/spring-boot-micrometer-tracing-autoconf/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
@@ -1,2 +1,3 @@
 com.digma.springboot.micrometer.autoconf.ObservedAutoConfiguration
 com.digma.springboot.otlp.autoconf.DigmaOtlpAutoConfiguration
+com.digma.springboot.otlp.autoconf.DigmaOtelSpringBootVersion3dot1AutoConfiguration

--- a/version.gradle.kts
+++ b/version.gradle.kts
@@ -1,5 +1,5 @@
 // keep the name theVersion and the val definition since script update_version.sh maintains it
-val theVersion = "0.7.4"
+val theVersion = "0.8.1-SNAPSHOT"
 
 allprojects {
     group = "io.github.digma-ai"

--- a/version.gradle.kts
+++ b/version.gradle.kts
@@ -1,5 +1,5 @@
 // keep the name theVersion and the val definition since script update_version.sh maintains it
-val theVersion = "0.8.1-SNAPSHOT"
+val theVersion = "0.7.7"
 
 allprojects {
     group = "io.github.digma-ai"


### PR DESCRIPTION
addresses issue: https://github.com/digma-ai/digma-intellij-plugin/issues/1456

supporting spring boot 3.0.x and 3.1.x
since spring boot 3.2.x can control OTEL resources attributes via environment variable prefix:

**MANAGEMENT_OPENTELEMETRY_RESOURCE-ATTRIBUTES**

for example:
MANAGEMENT_OPENTELEMETRY_RESOURCE-ATTRIBUTES_key_abc=val_xyx
it will add resource attribute named **key.abc** (yes with dot, _ becomes a dot) and value is **val_xyx**

`MANAGEMENT_OPENTELEMETRY_RESOURCE-ATTRIBUTES` environment variable prefix is equivalent to system property `management.opentelemetry.resource-attributes` just that delimiter is dot instead of underscore

for example system property
`-Dmanagement.opentelemetry.resource-attributes.key1=val2`

will create resource attribute named `key1` with value `val2`


### PR Outcome
can set digma environment in 3 spring boot versions:
3.0.x
3.1.x
3.2.x

in order to set digma environment add the following:

`MANAGEMENT_OPENTELEMETRY_RESOURCE-ATTRIBUTES_digma_environment=MY_ENV
`
it will create resource attribute named `digma.environment` with value of `MY_ENV`